### PR TITLE
Allow passing in external script dependencies via an environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,21 @@ USER hubot
 
 WORKDIR /home/hubot
 
+ENV DEV false
+
 ENV BOT_NAME "rocketbot"
+
+ENV EXTERNAL_SCRIPTS=hubot-diagnostics,hubot-help,hubot-google-images,hubot-google-translate,hubot-pugme,hubot-maps,hubot-rules,hubot-shipit
 
 RUN yo hubot --owner="S. Li <sli@makawave.com>" --name="$BOT_NAME" --description="bot for adapter development" --defaults && \
  sed -i /heroku/d ./external-scripts.json && \
- sed -i /redis-brain/d ./external-scripts.json
+ sed -i /redis-brain/d ./external-scripts.json && \
+ npm install hubot-rocketchat
 
-CMD coffee -c /home/hubot/node_modules/hubot-rocketchat/src/*.coffee && \
-bin/hubot -n $BOT_NAME -a rocketchat
+CMD node -e "console.log(JSON.stringify('$EXTERNAL_SCRIPTS'.split(',')))" > external-scripts.json && \
+ npm install $(node -e "console.log('$EXTERNAL_SCRIPTS'.split(',').join(' '))") && \
+ if $DEV; then coffee -c /home/hubot/node_modules/hubot-rocketchat/src/*.coffee; fi && \
+ bin/hubot -n $BOT_NAME -a rocketchat
 
-
+#CMD coffee -c /home/hubot/node_modules/hubot-rocketchat/src/*.coffee && \
+#bin/hubot -n $BOT_NAME -a rocketchat

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,3 @@ CMD node -e "console.log(JSON.stringify('$EXTERNAL_SCRIPTS'.split(',')))" > exte
  npm install $(node -e "console.log('$EXTERNAL_SCRIPTS'.split(',').join(' '))") && \
  if $DEV; then coffee -c /home/hubot/node_modules/hubot-rocketchat/src/*.coffee; fi && \
  bin/hubot -n $BOT_NAME -a rocketchat
-
-#CMD coffee -c /home/hubot/node_modules/hubot-rocketchat/src/*.coffee && \
-#bin/hubot -n $BOT_NAME -a rocketchat

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,12 @@ WORKDIR /home/hubot
 ENV DEV false
 
 ENV BOT_NAME "rocketbot"
+ENV BOT_OWNER "No owner specified"
+ENV BOT_DESC "Hubot with rocketbot adapter"
 
 ENV EXTERNAL_SCRIPTS=hubot-diagnostics,hubot-help,hubot-google-images,hubot-google-translate,hubot-pugme,hubot-maps,hubot-rules,hubot-shipit
 
-RUN yo hubot --owner="S. Li <sli@makawave.com>" --name="$BOT_NAME" --description="bot for adapter development" --defaults && \
+RUN yo hubot --owner="$BOT_OWNER" --name="$BOT_NAME" --description="$BOT_DESC" --defaults && \
  sed -i /heroku/d ./external-scripts.json && \
  sed -i /redis-brain/d ./external-scripts.json && \
  npm install hubot-rocketchat


### PR DESCRIPTION
Alright so need to add documentation for this.  But here's what i've got.

Four new environment variables:
* EXTERNAL_SCRIPTS
* DEV
* BOT_OWNER
* BOT_DESC

EXTERNAL_SCRIPTS can be a comma separated list. Automatically set to:
`hubot-diagnostics,hubot-help,hubot-google-images,hubot-google-translate,hubot-pugme,hubot-maps,hubot-rules,hubot-shipit` so this is not required.

DEV is automatically set to false.  But if set to true it will compile coffeescript files in `/home/hubot/node_modules/hubot-rocketchat/src/`

Couple of examples:

No Dev:  
```
docker run -it --link rocketchat:rocketchat -e ROCKETCHAT_URL=rocketchat -e ROCKETCHAT_ROOM=GENERAL -e ROCKETCHAT_USER=bot -e ROCKETCHAT_PASSWORD=bot -e BOT_NAME=bot -e EXTERNAL_SCRIPTS=hubot-pugme,hubot-help geekgonecrazy/rocketbot
```
Dev:
```
docker run -it --link rocketchat:rocketchat -e ROCKETCHAT_URL=rocketchat -e ROCKETCHAT_ROOM=GENERAL -e ROCKETCHAT_USER=bot -e ROCKETCHAT_PASSWORD=bot -e BOT_NAME=bot -e EXTERNAL_SCRIPTS=hubot-pugme,hubot-help -e DEV=true -v $PWD:/home/hubot/node_modules/hubot-rocketchat geekgonecrazy/rocketbot
```

@Sing-Li / @leefaus / @engelgabriel your input on this would also be awesome.

Also maybe we could setup an image on the rocketchat name that would hit the docker webhook to build any time a commit was made here?

Like rocketchat/rocketbot ?  Just an idea.  :)