### PR TITLE
Cleanup callback pyramid and log full error.

### DIFF
--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -10,66 +10,66 @@ _messageCollection = 'stream-messages'
 # plugs into generic rocketchatbotadapter
 
 class RocketChatDriver
-    constructor: (url, @logger, cb) ->
-        @asteroid = new Asteroid(url)
+  constructor: (url, @logger, cb) ->
+    @asteroid = new Asteroid(url)
 
-        @asteroid.on 'connected', ->
-            cb()
+    @asteroid.on 'connected', ->
+      cb()
 
-    getRoomId: (roomid) =>
-        @logger.info "Joining Room: #{roomid}"
+  getRoomId: (roomid) =>
+    @logger.info "Joining Room: #{roomid}"
 
-        r = @asteroid.call 'getRoomIdByNameOrId', roomid
+    r = @asteroid.call 'getRoomIdByNameOrId', roomid
 
-        return r.result
+    return r.result
 
-    joinRoom: (userid, uname, roomid, cb) =>
-        @logger.info "Joining Room: #{roomid}"
+  joinRoom: (userid, uname, roomid, cb) =>
+    @logger.info "Joining Room: #{roomid}"
 
-        r = @asteroid.call 'joinRoom', roomid
+    r = @asteroid.call 'joinRoom', roomid
 
-        return r.updated
+    return r.updated
 
-    sendMessage: (text, roomid) =>
-        @logger.info "Sending Message To Room: #{roomid}"
+  sendMessage: (text, roomid) =>
+    @logger.info "Sending Message To Room: #{roomid}"
 
-        @asteroid.call('sendMessage', {msg: text, rid: roomid})
+    @asteroid.call('sendMessage', {msg: text, rid: roomid})
 
-    login: (username, password) =>
-        @logger.info "Logging In"
-        # promise returned
-        return @asteroid.loginWithPassword username, password
+  login: (username, password) =>
+    @logger.info "Logging In"
+    # promise returned
+    return @asteroid.loginWithPassword username, password
 
-    prepMeteorSubscriptions: (data) =>
-        # use data to cater for param differences - until we learn more
-        #    data.uid
-        #    data.roomid
-        # return promise
-        @logger.info "Preparing Meteor Subscriptions.."
-        msgsub = @asteroid.subscribe _msgsubtopic, data.roomid, _msgsublimit
-        @logger.info "Subscribing to Room: #{data.roomid}"
-        return msgsub.ready
+  prepMeteorSubscriptions: (data) =>
+    # use data to cater for param differences - until we learn more
+    #  data.uid
+    #  data.roomid
+    # return promise
+    @logger.info "Preparing Meteor Subscriptions.."
+    msgsub = @asteroid.subscribe _msgsubtopic, data.roomid, _msgsublimit
+    @logger.info "Subscribing to Room: #{data.roomid}"
+    return msgsub.ready
 
-    setupReactiveMessageList: (receiveMessageCallback) =>
-        @logger.info "Setting up reactive message list..."
-        @messages = @asteroid.getCollection _messageCollection
+  setupReactiveMessageList: (receiveMessageCallback) =>
+    @logger.info "Setting up reactive message list..."
+    @messages = @asteroid.getCollection _messageCollection
 
-        rQ = @messages.reactiveQuery {}
-        rQ.on "change", (id) =>
-            # awkward syntax due to asteroid limitations
-            # - it ain't no minimongo cursor
-            @logger.info "Change received on ID " + id
-            changedMsgQuery = @messages.reactiveQuery {"_id": id}
-            if changedMsgQuery.result && changedMsgQuery.result.length > 0
-                # console.log('result:', JSON.stringify(changedMsgQuery.result, null, 2))
-                changedMsg = changedMsgQuery.result[0]
-                # console.log('changed:', JSON.stringify(changedMsg, null, 2));
-                if changedMsg.args?
-                    receiveMessageCallback changedMsg.args[1]
+    rQ = @messages.reactiveQuery {}
+    rQ.on "change", (id) =>
+      # awkward syntax due to asteroid limitations
+      # - it ain't no minimongo cursor
+      @logger.info "Change received on ID " + id
+      changedMsgQuery = @messages.reactiveQuery {"_id": id}
+      if changedMsgQuery.result && changedMsgQuery.result.length > 0
+        # console.log('result:', JSON.stringify(changedMsgQuery.result, null, 2))
+        changedMsg = changedMsgQuery.result[0]
+        # console.log('changed:', JSON.stringify(changedMsg, null, 2));
+        if changedMsg.args?
+          receiveMessageCallback changedMsg.args[1]
 
-    callMethod: (name, args = []) =>
-        @logger.info "Calling: #{name}, #{args.join(', ')}"
-        r = @asteroid.apply name, args
-        return r.result
+  callMethod: (name, args = []) =>
+    @logger.info "Calling: #{name}, #{args.join(', ')}"
+    r = @asteroid.apply name, args
+    return r.result
 
 module.exports = RocketChatDriver


### PR DESCRIPTION
Compare with [this link](https://github.com/RocketChat/hubot-rocketchat/pull/86/files?w=1) to eliminate whitespace changes.

This fixes the unreadable code as seen below:

![screen shot 2015-12-21 at 9 56 59 am](https://cloud.githubusercontent.com/assets/1197375/11935559/14662742-a7ce-11e5-8f7c-3844b9bd6e38.jpg)

This also stringifies errors when reporting them. This helped with a frustrating issue where Rocket.Chat was refusing my password due to a special character, but hubot was only logging `[object Object]`.

Tested working on a live hubot instance.