### PR TITLE
Allow Rich Messages

### DIFF
--- a/src/rocketchat.coffee
+++ b/src/rocketchat.coffee
@@ -136,12 +136,15 @@ class RocketChatBotAdapter extends Adapter
 			)
 
 	send: (envelope, strings...) =>
-			@chatdriver.sendMessage(str, envelope.room) for str in strings
+		@chatdriver.sendMessage(str, envelope.room) for str in strings
+			
+	customMessage: (data) =>
+		@chatdriver.customMessage(data)
 
 	reply: (envelope, strings...) =>
-			@robot.logger.info "reply"
-			strings = strings.map (s) -> "@#{envelope.user.name} #{s}"
-			@send envelope, strings...
+		@robot.logger.info "reply"
+		strings = strings.map (s) -> "@#{envelope.user.name} #{s}"
+		@send envelope, strings...
 
 	callMethod: (method, args...) =>
 		@chatdriver.callMethod(method, args)

--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -39,6 +39,11 @@ class RocketChatDriver
 		@logger.info "Sending Message To Room: #{roomid}"
 
 		@asteroid.call('sendMessage', {msg: text, rid: roomid})
+		
+	customMessage: (message) =>
+		@logger.info "Sending Custom Message To Room: #{message.channel}"
+
+		@asteroid.call('sendMessage', {msg: "", rid: message.channel, attachments: message.attachments, bot: true, groupable: false})
 
 	login: (username, password) =>
 		@logger.info "Logging In"


### PR DESCRIPTION
Allows things like:

![image](https://cloud.githubusercontent.com/assets/51996/12527868/546d84d0-c14a-11e5-89af-de94e6595bd5.png)

Allows you to do something like:

```
robot.adapter.customMessage({
  channel: room,
  attachments: [
    {
       title: "[#{repo.full_name}] New Comment on #{issue_pull}: \##{issue.number}",
       title_link: issue.html_url,
       text: "<img src=\"#{comment.user.avatar_url}\" width=\"20\" /> <a href=\"{comment.user.html_url}\">#{comment.user.login}</a>: <br /> #{comment.body}"
    }
  ]
});
```

Inspiration for this approach:

http://baudehlo.com/2015/11/20/creating-nice-looking-slack-bot-messages-with-hubot/