### PR TITLE
Let sendMessage lookup roomid and added caching to getRoomId (#98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ ROCKETCHAT_AUTH | defaults to 'password' if undefinied, or set to 'ldap' if your
 ROCKETCHAT_ROOM | the channel/channels names the bot should listen to message from.  This can be comma separated list.
 LISTEN_ON_ALL_PUBLIC | if 'true' then bot will listen and respond to messages from all public channels, as well as respond to direct messages. Default to 'false'. ROCKETCHAT_ROOM should be set to empty (with `ROCKETCHAT_ROOM=''` ) when using `LISTEN_ON_ALL_PUBLIC`. *IMPORTANT NOTE*:  This option also allows the bot to listen and respond to messages _from all newly created private groups_ that the bot's user has been added as a member.
 RESPOND_TO_DM | if 'true' then bot will listen and respond to direct messages. When setting the option to 'true', be sure to also set ROCKETCHAT_ROOM. This option needs not be set if you are including LISTEN_ON_ALL_PUBLIC.    Default is 'false'.
+ROOM_ID_CACHE_SIZE | The maximum number of room IDs to cache. You can increase this if your bot usually sends messages to a large number of different rooms. Default value: 10
+ROOM_ID_CACHE_MAX_AGE | Room IDs are cached for this number of seconds. You can increase this value to improve performance in certain scenarios. Default value: 300
 BOT_NAME | ** Name of the bot.  This is what it responds to
 EXTERNAL_SCRIPTS | ** These are the npm modules it will add to hubot.
 DEV | ** This enables development mode.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "asteroid": "git://github.com/RocketChat/asteroid.git",
     "parent-require": "^1.0.0",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "lru-cache": "~4.0.0"
   }
 }

--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -7,7 +7,11 @@ LRU = require('lru-cache')
 _msgsubtopic = 'stream-messages' # 'messages'
 _msgsublimit = 10   # this is not actually used right now
 _messageCollection = 'stream-messages'
-_roomIdCache = LRU( max: 10, maxAge: 1000 * 20 )
+
+# room id cache
+_cacheSize = parseInt(process.env.ROOM_ID_CACHE_SIZE) || 10
+_cacheMaxAge = parseInt(process.env.ROOM_ID_CACHE_MAX_AGE) || 300
+_roomIdCache = LRU( max: _cacheSize, maxAge: 1000 * _cacheMaxAge )
 
 # driver specific to Rocketchat hubot integration
 # plugs into generic rocketchatbotadapter

--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -31,6 +31,7 @@ class RocketChatDriver
 	getRoomId: (room) =>
 		cached = _roomIdCache.get room
 		if cached
+			@logger.debug "Found cached Room ID for #{room}: #{cached}"
 			return Q(cached)
 		else
 			@logger.info "Looking up Room ID for: #{room}"


### PR DESCRIPTION
This patch does two things:

* `RocketChatDriver.sendMessage()` now uses `getRoomId` to resolve the id of the requested room
* `RocketChatDriver.getRoomId()` uses a LRU cache to reduce the number of calls to the server

I tested the patch and it looks good. The "max age" setting for the cache should be configurable, but I guess this should be done in a later PR.