### PR TITLE
Direct Message functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ ROCKETCHAT_ROOM | the channel/channels names the bot should listen to message fr
 LISTEN_ON_ALL_PUBLIC | if 'true' then bot will listen and respond to messages from all public channels, as well as respond to direct messages. Default to 'false'. ROCKETCHAT_ROOM should be set to empty (with `ROCKETCHAT_ROOM=''` ) when using `LISTEN_ON_ALL_PUBLIC`. *IMPORTANT NOTE*:  This option also allows the bot to listen and respond to messages _from all newly created private groups_ that the bot's user has been added as a member.
 RESPOND_TO_DM | if 'true' then bot will listen and respond to direct messages. When setting the option to 'true', be sure to also set ROCKETCHAT_ROOM. This option needs not be set if you are including LISTEN_ON_ALL_PUBLIC.    Default is 'false'.
 ROOM_ID_CACHE_SIZE | The maximum number of room IDs to cache. You can increase this if your bot usually sends messages to a large number of different rooms. Default value: 10
-ROOM_ID_CACHE_MAX_AGE | Room IDs are cached for this number of seconds. You can increase this value to improve performance in certain scenarios. Default value: 300
+DM_ROOM_ID_CACHE_SIZE | The maximum number of Direct Message room IDs to cache. You can increase this if your bot usually sends a large number of Direct Messages. Default value: 100
+ROOM_ID_CACHE_MAX_AGE | Room IDs and DM Room IDS are cached for this number of seconds. You can increase this value to improve performance in certain scenarios. Default value: 300
 BOT_NAME | ** Name of the bot.  This is what it responds to
 EXTERNAL_SCRIPTS | ** These are the npm modules it will add to hubot.
 DEV | ** This enables development mode.

--- a/src/rocketchat.coffee
+++ b/src/rocketchat.coffee
@@ -155,7 +155,7 @@ class RocketChatBotAdapter extends Adapter
 		Q(channel)
 		.then((chan) =>
 			envelope.room = chan.rid
-			@send envelope, strings...
+			@chatdriver.sendMessageByRoomId(str, envelope.room) for str in strings
 		)
 		.catch((err) =>
 			@robot.logger.error "Unable to get DirectMessage Room ID: #{JSON.stringify(err)} Reason: #{err.reason}"

--- a/src/rocketchat.coffee
+++ b/src/rocketchat.coffee
@@ -157,6 +157,9 @@ class RocketChatBotAdapter extends Adapter
 			envelope.room = chan.rid
 			@send envelope, strings...
 		)
+		.catch((err) =>
+			@robot.logger.error "Unable to get DirectMessage Room ID: #{JSON.stringify(err)} Reason: #{err.reason}"
+		)
 
 	reply: (envelope, strings...) =>
 		@robot.logger.info "reply"

--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -9,9 +9,11 @@ _msgsublimit = 10   # this is not actually used right now
 _messageCollection = 'stream-messages'
 
 # room id cache
-_cacheSize = parseInt(process.env.ROOM_ID_CACHE_SIZE) || 10
+_roomCacheSize = parseInt(process.env.ROOM_ID_CACHE_SIZE) || 10
+_directMessageRoomCacheSize = parseInt(process.env.DM_ROOM_ID_CACHE_SIZE) || 100
 _cacheMaxAge = parseInt(process.env.ROOM_ID_CACHE_MAX_AGE) || 300
-_roomIdCache = LRU( max: _cacheSize, maxAge: 1000 * _cacheMaxAge )
+_roomIdCache = LRU( max: _roomCacheSize, maxAge: 1000 * _cacheMaxAge )
+_directMessageRoomIdCache = LRU( max: _directMessageRoomCacheSize, maxAge: 1000 * _cacheMaxAge )
 
 # driver specific to Rocketchat hubot integration
 # plugs into generic rocketchatbotadapter
@@ -29,23 +31,23 @@ class RocketChatDriver
 			cb()
 
 	getRoomId: (room) =>
-		cached = _roomIdCache.get room
-		if cached
-			@logger.debug "Found cached Room ID for #{room}: #{cached}"
-			return Q(cached)
-		else
-			@logger.info "Looking up Room ID for: #{room}"
-			r = @asteroid.call 'getRoomIdByNameOrId', room
-			return r.result.then (roomid) =>
-				_roomIdCache.set room, roomid
-				return Q(roomid)
+		@tryCache _roomIdCache, 'getRoomIdByNameOrId', room, 'Room ID'
 
 	getDirectMessageRoomId: (username) =>
-		@logger.info "Looking up DM Room ID for: #{username}"
+		@tryCache _directMessageRoomIdCache, 'createDirectMessage', username, 'DM Room ID'
 
-		r = @asteroid.call 'createDirectMessage', username
-
-		return r.result
+	tryCache: (cacheArray, method, key, name) =>
+		name ?= method
+		cached = cacheArray.get key
+		if cached
+			@logger.debug "Found cached #{name} for #{key}: #{cached}"
+			return Q(cached)
+		else
+			@logger.info "Looking up #{name} for: #{key}"
+			r = @asteroid.call method, key
+			return r.result.then (res) =>
+				cacheArray.set key, res
+				return Q(res)
 
 	joinRoom: (userid, uname, roomid, cb) =>
 		@logger.info "Joining Room: #{roomid}"
@@ -58,7 +60,10 @@ class RocketChatDriver
 		@logger.info "Sending Message To Room: #{room}"
 		r = @getRoomId room
 		r.then (roomid) =>
-			@asteroid.call('sendMessage', {msg: text, rid: roomid})
+			@sendMessageByRoomId text, roomid
+
+	sendMessageByRoomId: (text, roomid) =>
+		@asteroid.call('sendMessage', {msg: text, rid: roomid})
 
 	customMessage: (message) =>
 		@logger.info "Sending Custom Message To Room: #{message.channel}"

--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -28,6 +28,13 @@ class RocketChatDriver
 
 		return r.result
 
+	getDirectMessageRoomId: (username) =>
+		@logger.info "Looking up DM Room ID for: #{username}"
+
+		r = @asteroid.call 'createDirectMessage', username
+
+		return r.result
+
 	joinRoom: (userid, uname, roomid, cb) =>
 		@logger.info "Joining Room: #{roomid}"
 


### PR DESCRIPTION
Script for hubot to respond with a Direct Message to a user who typed a command on a public-channel. ( Good to keep chaos out of the main channels, and this way new scripts can be created that give the user private information )
This allows hubot scripts to use something like this:

```coffee
robot.respond /DM me/i, (res) ->
    res.sendDirect "This is a DM"
```
NOTE: currently you can use `sendDirect` and `sendPrivate`, couldn't decide on a name.
* sendPrivate is used in the [hubot irc adapter](https://github.com/nandub/hubot-irc/pull/118/files)
* sendDirect is more in-line with the RocketChat 'DM' naming convention

most adapters have not implemented something like this because you can use this in them:
```coffee
robot.send {room: message.envelope.user.name}, message
```
This can not be used in RocketChat because DM channel IDs are created by concatenating the 2 user IDs, so we actually need to ask for the Room ID. ( the method also creates the channel if it didn't exist till now )

Any improvements are welcomed.