### PR TITLE
Filter empty room name

### DIFF
--- a/src/rocketchat.coffee
+++ b/src/rocketchat.coffee
@@ -62,7 +62,8 @@ class RocketChatBotAdapter extends Adapter
 			@robot.logger.info "Successfully connected!"
 			@robot.logger.info RocketChatRoom
 
-			rooms = RocketChatRoom.split(',')
+			rooms = RocketChatRoom.split(',').filter (room) ->
+				room != ''
 			# @robot.logger.info JSON.stringify(rooms)
 
 			# Log in


### PR DESCRIPTION
Related to #115 

Hubot crashes during startup, because the RocketChatRoom is a empty strings.

This is the error messages from my docker container

```
hubot_1       | [Fri May 13 2016 09:59:02 GMT+0000 (UTC)] INFO Looking up Room ID for: ''
rocketchat_1  | Exception while invoking method 'getRoomIdByNameOrId' TypeError: Cannot read property 'usernames' of undefined
rocketchat_1  |     at [object Object].Meteor.methods.getRoomIdByNameOrId (server/methods/getRoomIdByNameOrId.coffee:8:10)
rocketchat_1  |     at [object Object].methodsMap.(anonymous function) (server/lib/debug.js:23:26)
rocketchat_1  |     at maybeAuditArgumentChecks (livedata_server.js:1698:12)
rocketchat_1  |     at livedata_server.js:708:19
rocketchat_1  |     at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)
rocketchat_1  |     at livedata_server.js:706:40
rocketchat_1  |     at [object Object]._.extend.withValue (packages/meteor/dynamics_nodejs.js:56:1)
rocketchat_1  |     at livedata_server.js:704:46
rocketchat_1  |     at tryCallTwo (/app/bundle/programs/server/npm/promise/node_modules/meteor-promise/node_modules/promise/lib/core.js:45:5)
rocketchat_1  |     at doResolve (/app/bundle/programs/server/npm/promise/node_modules/meteor-promise/node_modules/promise/lib/core.js:171:13)
hubot_1       | [Fri May 13 2016 09:59:03 GMT+0000 (UTC)] ERROR Unable to get room id: {"error":500,"reason":"Internal server error","message":"Internal server error [500]","errorType":"Meteor.Error"} Reason: Internal server error
hubot_1       | [Fri May 13 2016 09:59:03 GMT+0000 (UTC)] ERROR {"error":500,"reason":"Internal server error","message":"Internal server error [500]","errorType":"Meteor.Error"}
hubot_1       | [Fri May 13 2016 09:59:03 GMT+0000 (UTC)] ERROR Unable to complete setup. See https://github.com/RocketChat/hubot-rocketchat for more info.
```