### PR TITLE
Switch to using repo version in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ USER hubot
 
 WORKDIR /home/hubot
 
-ENV DEV false
-
 ENV BOT_NAME "rocketbot"
 ENV BOT_OWNER "No owner specified"
 ENV BOT_DESC "Hubot with rocketbot adapter"
@@ -19,10 +17,20 @@ ENV EXTERNAL_SCRIPTS=hubot-diagnostics,hubot-help,hubot-google-images,hubot-goog
 RUN yo hubot --owner="$BOT_OWNER" --name="$BOT_NAME" --description="$BOT_DESC" --defaults && \
 	sed -i /heroku/d ./external-scripts.json && \
 	sed -i /redis-brain/d ./external-scripts.json && \
-	npm install hubot-rocketchat && \
 	npm install hubot-scripts
+
+ADD . /home/hubot/node_modules/hubot-rocketchat
+
+# hack added to get around owner issue: https://github.com/docker/docker/issues/6119
+USER root
+RUN chown hubot:hubot -R /home/hubot/node_modules/hubot-rocketchat
+USER hubot
+
+RUN cd /home/hubot/node_modules/hubot-rocketchat && \
+	npm install && \
+	coffee -c /home/hubot/node_modules/hubot-rocketchat/src/*.coffee && \
+	cd /home/hubot
 
 CMD node -e "console.log(JSON.stringify('$EXTERNAL_SCRIPTS'.split(',')))" > external-scripts.json && \
 	npm install $(node -e "console.log('$EXTERNAL_SCRIPTS'.split(',').join(' '))") && \
-	if $DEV; then coffee -c /home/hubot/node_modules/hubot-rocketchat/src/*.coffee; fi && \
 	bin/hubot -n $BOT_NAME -a rocketchat

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ DM_ROOM_ID_CACHE_SIZE | The maximum number of Direct Message room IDs to cache. 
 ROOM_ID_CACHE_MAX_AGE | Room IDs and DM Room IDS are cached for this number of seconds. You can increase this value to improve performance in certain scenarios. Default value: 300
 BOT_NAME | ** Name of the bot.  This is what it responds to
 EXTERNAL_SCRIPTS | ** These are the npm modules it will add to hubot.
-DEV | ** This enables development mode.
 
 ** - Docker image only.
 ##### Configuring the Bot to listen and respond to direct messages plus all new public channels and private groups
@@ -193,7 +192,6 @@ docker run -it -e ROCKETCHAT_URL=<your rocketchat instance>:<port> \
 	-e ROCKETCHAT_AUTH=password \
 	-e BOT_NAME=bot \
 	-e EXTERNAL_SCRIPTS=hubot-pugme,hubot-help \
-	-e DEV=true \
 	-v $PWD:/home/hubot/node_modules/hubot-rocketchat rocketchat/hubot-rocketchat
 ```
 


### PR DESCRIPTION
Previously we always used npm's version regardless.  Now when we do a docker build we are using the repo's code.  This will allow us to test different versions of the hubot container and use docker.