### PR TITLE
Don’t mention user in DM

### DIFF
--- a/src/rocketchat.coffee
+++ b/src/rocketchat.coffee
@@ -190,7 +190,9 @@ class RocketChatBotAdapter extends Adapter
 
 	reply: (envelope, strings...) =>
 		@robot.logger.info "reply"
-		strings = strings.map (s) -> "@#{envelope.user.name} #{s}"
+		isDM = envelope.room.indexOf(envelope.user.id) > -1
+		unless isDM
+			strings = strings.map (s) -> "@#{envelope.user.name} #{s}"
 		@send envelope, strings...
 
 	callMethod: (method, args...) =>


### PR DESCRIPTION
Hubot will mention the user in every reply by default:

    user >> hubot ping
    hubot >> @user pong

That makes sense in public channels, you need to see who hubot is talking to.

In a DM however, it looks bad having mentions with every reply when its just you and the bot talking. e.g. 

    user >> ping
    hubot >> @user pong

This fixes that...

    user >> ping
    hubot >> pong
