### PR TITLE
Add missing message params to set user name and avatar

### DIFF
--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -88,7 +88,15 @@ class RocketChatDriver
 	customMessage: (message) =>
 		@logger.info "Sending Custom Message To Room: #{message.channel}"
 
-		@asteroid.call('sendMessage', {msg: "", rid: message.channel, attachments: message.attachments, bot: true, groupable: false})
+		@asteroid.call('sendMessage', {
+			msg: message.msg || '',
+			rid: message.channel,
+			attachments: message.attachments,
+			bot: true,
+			groupable: false,
+			alias: message.alias,
+			avatar: message.avatar
+		})
 
 	login: (username, password) =>
 		@logger.info "Logging In"


### PR DESCRIPTION
Add option to set a user icon and a user name for the bot when sending custom messages
e.g. JIRA username and JIRA icon