### PR TITLE
Fix bug where user data in bot's brain is reset when users change rooms

### DIFF
--- a/src/rocketchat.coffee
+++ b/src/rocketchat.coffee
@@ -153,12 +153,13 @@ class RocketChatBotAdapter extends Adapter
 
 					if curts > @lastts
 						@lastts = curts
+						
+						user = @robot.brain.userForId newmsg.u._id, name: newmsg.u.username
+						user.room = newmsg.rid
+
 						if newmsg.t is 'uj'
-							user = @robot.brain.userForId newmsg.u._id, name: newmsg.u.username, room: newmsg.rid
 							@robot.receive new EnterMessage user, null, newmsg._id
 						else
-							user = @robot.brain.userForId newmsg.u._id, name: newmsg.u.username, room: newmsg.rid
-
 							# check for the presence of attachments in the message
 							if newmsg.file? and newmsg.attachments.length
 								attachment = newmsg.attachments[0]


### PR DESCRIPTION
I noticed extra user data saved in my bot's brain is lost when a user changes room (see #178).

The root of the issue is the `brain.userForId()` method.  If it can't find a user with the ID and options specified, it returns a new user object ([source here](https://github.com/github/hubot/blob/master/src/brain.coffee#L103-L113)).  

In this case we were asking for the user in the _new_ room.  As the brain hasn't been updated yet the bot never finds the user and always returns a new user - effectively losing any additional data saved for that user in the brain.

My fix asks the brain for the user by ID, and then sets the new room.  We don't need to explicitly call `brain.save()` because Hubot automatically saves the brain every second for us.
