### PR TITLE
EnterMessage now triggered by users who are /invited

### DIFF
--- a/src/rocketchat.coffee
+++ b/src/rocketchat.coffee
@@ -153,11 +153,15 @@ class RocketChatBotAdapter extends Adapter
 
 					if curts > @lastts
 						@lastts = curts
-						
-						user = @robot.brain.userForId newmsg.u._id, name: newmsg.u.username
+
+						if newmsg.t is 'au' and newmsg.added
+							user = @robot.brain.userForId newmsg.added._id, name: newmsg.msg
+							addedUser = true
+
+						user = user || @robot.brain.userForId newmsg.u._id, name: newmsg.u.username
 						user.room = newmsg.rid
 
-						if newmsg.t is 'uj'
+						if newmsg.t is 'uj' or addedUser
 							@robot.receive new EnterMessage user, null, newmsg._id
 						else
 							# check for the presence of attachments in the message


### PR DESCRIPTION
See https://github.com/RocketChat/Rocket.Chat/pull/5158

It seems an oversight that only users who actively join a channel (messagetype == 'uj') get an `EnterMessage`. This change, in conjunction with the [PR](https://github.com/RocketChat/Rocket.Chat/pull/5158) above, means /inviting a user also triggers an `EnterMessage`.