### PR TITLE
Wrap sendMessage in Q promise.

### DIFF
--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -79,7 +79,7 @@ class RocketChatDriver
 
 	sendMessageByRoomId: (content, roomid) =>
 		message = @prepareMessage content, roomid
-		@asteroid.call('sendMessage', message)
+		Q(@asteroid.call('sendMessage', message))
 		.then (result)->
 			@logger.debug('[sendMessage] Success:', result)
 		.catch (error) ->


### PR DESCRIPTION
I found that `asteroid.call('sendMessage', message)` did not always return a promise, or possibly a "partially functional" then. This was breaking my promise chains in Hubot methods that invoked `sendMessageByRoomId`. So I wrapped it in `Q` as described in Q docs...

>When working with promises provided by other libraries, you should convert it to a Q promise. Not all promise libraries make the same guarantees as Q and certainly don’t provide all of the same methods. Most libraries only provide a partially functional then method. This thankfully is all we need to turn them into vibrant Q promises.