### PR TITLE
Updating the node version to 6.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.12.4
+FROM node:6.10.3
 MAINTAINER Rocket.Chat Team <buildmaster@rocket.chat>
 
 RUN npm install -g coffee-script yo generator-hubot  &&  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.10.3
+FROM node:4.8.3
 MAINTAINER Rocket.Chat Team <buildmaster@rocket.chat>
 
 RUN npm install -g coffee-script yo generator-hubot  &&  \


### PR DESCRIPTION
Since 

1. as per node version 6 release notes it is 4 times faster than node 4.
2. 0.12.4 version is deprecated.

fixes #202 