### PR TITLE
clarified readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Regular hubot via: `export VAR=Value` or add to pm2 etc
 
 Environment Variable | Description
 :---- | :----
-ROCKETCHAT_URL | the URL where Rocket.Chat is running, can be specified as `host:port` or `http://host:port`  or `https://host:port`. If you are using `https://`, you **MUST** setup websocket pass-through on your reverse proxy (NGINX, and so on) with a valid certificate (not self-signed).  Directly accessing Rocket.Chat without a reverse proxy via `https://` is not possible.
+ROCKETCHAT_URL | the IP address where Rocket.Chat is running, can be specified as `host:port` or `http://host:port`  or `https://host:port`. If you are using `https://`, you **MUST** setup websocket pass-through on your reverse proxy (NGINX, and so on) with a valid certificate (not self-signed).  Directly accessing Rocket.Chat without a reverse proxy via `https://` is not possible.
 ROCKETCHAT_USER | the bot user's name. It must be a registered user on your Rocket.Chat server, and the user must be granted `bot` role via Rocket.Chat's administrator's panel  (note that this will also be the name that you can summon the bot with)
 ROCKETCHAT_PASSWORD | the bot user's password
 ROCKETCHAT_AUTH | defaults to 'password' if undefinied, or set to 'ldap' if your use LDAP accounts for bots.


### PR DESCRIPTION
The ROCKETCHAT_URL env variable accepts IP addresses, not URLs (or at least, for me, it did not - not sure if that's a function of corporate proxies). Spent a couple hours very confused as to why I was unable to connect to my Rocket.Chat setup when specifying the URL 