### PR TITLE
Add missing emoji param to customMessage method

### DIFF
--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -99,7 +99,8 @@ class RocketChatDriver
 			bot: true,
 			groupable: false,
 			alias: message.alias,
-			avatar: message.avatar
+			avatar: message.avatar,
+			emoji: message.emoji,
 		})
 
 	login: (username, password) =>


### PR DESCRIPTION
`customMessage` methods didn't support `emoji` param.