### PR TITLE
Allow external scripts to be retrieved from personnal git repositories via HTTP(S)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ RUN cd /home/hubot/node_modules/hubot-rocketchat && \
 	coffee -c /home/hubot/node_modules/hubot-rocketchat/src/*.coffee && \
 	cd /home/hubot
 
-CMD node -e "console.log(JSON.stringify('$EXTERNAL_SCRIPTS'.split(',')))" > external-scripts.json && \
+CMD node -e "console.log(JSON.stringify('$EXTERNAL_SCRIPTS'.split(',').map(elem => elem.replace(/git\+https?\:\/\/.*\/(.*).git/, '\$1'))))" > external-scripts.json && \
 	npm install $(node -e "console.log('$EXTERNAL_SCRIPTS'.split(',').join(' '))") && \
 	bin/hubot -n $BOT_NAME -a rocketchat

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ ROOM_ID_CACHE_SIZE | The maximum number of room IDs to cache. You can increase t
 DM_ROOM_ID_CACHE_SIZE | The maximum number of Direct Message room IDs to cache. You can increase this if your bot usually sends a large number of Direct Messages. Default value: 100
 ROOM_ID_CACHE_MAX_AGE | Room IDs and DM Room IDS are cached for this number of seconds. You can increase this value to improve performance in certain scenarios. Default value: 300
 BOT_NAME | ** Name of the bot.  This is what it responds to
-EXTERNAL_SCRIPTS | ** These are the npm modules it will add to hubot.
+EXTERNAL_SCRIPTS | ** These are the npm modules it will add to hubot. Could be git+https or git+http protocol urls (see [here](https://docs.npmjs.com/cli/install) for details) if your script is not on the NPM public registry.
 
 ** - Docker image only.
 ##### Configuring the Bot to listen and respond to direct messages plus all new public channels and private groups


### PR DESCRIPTION
You can now specify git+http or git+https urls as a script in the EXTERNAL_SCRIPTS env variable.
Useful when user doesn't want to publish his script on the public NPM registry.

Ex : `-e EXTERNAL_SCRIPTS=hubot-pugme,hubot-help,git+https://user:token@repo/hubot-ping.git`

/cc @davinkevin