### PR TITLE
add new feature 'get user roles' from rocketchat

### DIFF
--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -91,6 +91,14 @@ class RocketChatDriver
 
 		return r.updated
 
+	# added this method so the User class in hubot will have access to the user's role
+	getUserRoles: () =>
+		@logger.info "Getting user Roles"
+
+		r = @asteroid.call 'getUserRoles'
+		
+		return r.result
+
 	prepareMessage: (content, roomid) =>
 		@logger.debug "Preparing message from #{ typeof content }"
 		if typeof content is 'string'
@@ -153,7 +161,7 @@ class RocketChatDriver
 	setupReactiveMessageList: (receiveMessageCallback) =>
 		@logger.info "Setting up reactive message list..."
 		@messages = @asteroid.getCollection _messageCollection
-
+		
 		rQ = @messages.reactiveQuery {}
 		rQ.on "change", (id) =>
 			# awkward syntax due to asteroid limitations


### PR DESCRIPTION
Created this feature so Hubot can access the users role of the message that was sent to hubot.
- the users roles can be easily accessed in any script by using the _res.message.user.roles_ property, where the type will be an array.
- was tested locally and had no errors
- roles will always be up to date because they are grabbed each time a new message is recieved