### PR TITLE
Send delay on outgoing messages

### DIFF
--- a/src/rocketchat_driver.coffee
+++ b/src/rocketchat_driver.coffee
@@ -21,7 +21,12 @@ _roomIdCache = LRU(max: _roomCacheSize, maxAge: 1000 * _cacheMaxAge)
 _directMessageRoomIdCache = LRU(max: _directMessageRoomCacheSize, maxAge: 1000 * _cacheMaxAge)
 _roomNameCache = LRU(max: _roomCacheSize, maxAge: 1000 * _cacheMaxAge)
 
-# driver specific to Rocketchat hubot integration
+_queues = {}
+_delayTime = parseInt(process.env.SEND_DELAY)
+_msgLastSentTimes = {}
+_intervalTimers = {}
+		
+		# driver specific to Rocketchat hubot integration
 # plugs into generic rocketchatbotadapter
 
 class RocketChatDriver
@@ -100,19 +105,54 @@ class RocketChatDriver
 			message.rid = roomid
 		return message
 
+	asteroidSend: (message, roomid) ->
+		_msgLastSentTimes[roomid] = Date.now() if _delayTime > 0
+		
+		Q(@asteroid.call('sendMessage', message))
+			.then (result) =>
+				@logger.debug('[sendMessage] Success:', result)
+			.catch (error) =>
+				@logger.error('[sendMessage] Error:', error)
+
+	slowSender: (roomid) ->
+		if (message = _queues[roomid].shift()) != undefined
+			@asteroidSend message, roomid
+		# if there's still stuff to send then
+		# restart the interval timer to <_delayTime> ms
+		if _queues[roomid].length
+			if not _intervalTimers[roomid]
+				_intervalTimers[roomid] = setInterval slowSender, _delayTime, roomid
+		else
+			# clear and null our interval timer
+			clearInterval _intervalTimers[roomid]
+			_intervalTimers[roomid] = null
+
+	sendMessageByRoomId: (content, roomid) =>
+		message = @prepareMessage content, roomid
+
+		waitTimeAgo = Date.now() - _delayTime
+		# see how long it is since the last message was sent
+		if _msgLastSentTimes[roomid] > waitTimeAgo
+			console.log "I can\'t keep up with you: #{message.msg}"
+
+			# enqueue the message
+			_queues[roomid] = [] if !_queues[roomid] 
+			_queues[roomid].push message
+
+			# start an interval timer if necessary
+			if !_intervalTimers[roomid]
+				console.log "Will send this message in #{_msgLastSentTimes[roomid] - waitTimeAgo}ms"
+				_intervalTimers[roomid] = setInterval @slowSender.bind(@), _msgLastSentTimes[roomid] - waitTimeAgo, roomid
+				# don't go any further
+		else
+			# send the message
+			@asteroidSend message, roomid
+
 	sendMessage: (message, room) =>
 		@logger.info "Sending Message To Room: #{room}"
 		r = @getRoomId room
 		r.then (roomid) =>
 			@sendMessageByRoomId message, roomid
-
-	sendMessageByRoomId: (content, roomid) =>
-		message = @prepareMessage content, roomid
-		Q(@asteroid.call('sendMessage', message))
-		.then (result)->
-			@logger.debug('[sendMessage] Success:', result)
-		.catch (error) ->
-			@logger.error('[sendMessage] Error:', error)
 
 	customMessage: (message) =>
 		@logger.info "Sending Custom Message To Room: #{message.channel}"


### PR DESCRIPTION
This feature allows you to throttle outgoing messages.

Just set the `SEND_DELAY` env variable, and hubot will ensure only one message is sent per _SEND_DELAY_ milliseconds. This uses per-room interval timers to ensure multiple conversations are throttled correctly.