### PR TITLE
added support for adapter env vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,12 @@ class RocketChatBotAdapter extends Adapter {
     this.driver = driver
     this.methodCache = methodCache
     this.api = api
+
+    settings.host = process.env.ROCKETCHAT_URL || 'localhost';
+    settings.username = process.env.ROCKETCHAT_USER || 'bot';
+    settings.password = process.env.ROCKETCHAT_PASS || 'bot';
+    settings.useSsl = (process.env.ROCKETCHAT_USESSL === '') ? true : process.env.ROCKETCHAT_USESSL;  // server uses https ?
+    settings.rooms = (process.env.ROCKETCHAT_ROOM === '') ? ['general'] : [process.env.ROCKETCHAT_ROOM];
     this.settings = settings
 
     // Print logs with current configs

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ class RocketChatBotAdapter extends Adapter {
     settings.username = process.env.ROCKETCHAT_USER || 'bot';
     settings.password = process.env.ROCKETCHAT_PASS || 'bot';
     settings.useSsl = (process.env.ROCKETCHAT_USESSL === '') ? true : process.env.ROCKETCHAT_USESSL;  // server uses https ?
-    settings.rooms = (process.env.ROCKETCHAT_ROOM === '') ? ['general'] : [process.env.ROCKETCHAT_ROOM];
+    settings.rooms = (process.env.ROCKETCHAT_ROOM === '') ? ['GENERAL'] : [process.env.ROCKETCHAT_ROOM];
     this.settings = settings
 
     // Print logs with current configs


### PR DESCRIPTION
The latest hubot-rocketchat boilerplate instructs users to set up RC environment variables but they are never used in hubot-rocketchat.

This is a fairly quick fix, as I presume there is a longer term strategy to deal with env vars.
