### PR TITLE
use COPY --chown=hubot:hubot over ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,7 @@ RUN yo hubot --owner="$BOT_OWNER" --name="$BOT_NAME" --description="$BOT_DESC" -
 	sed -i /redis-brain/d ./external-scripts.json && \
 	npm install hubot-scripts
 
-ADD . /home/hubot/node_modules/hubot-rocketchat
-
-# hack added to get around owner issue: https://github.com/docker/docker/issues/6119
-USER root
-RUN chown hubot:hubot -R /home/hubot/node_modules/hubot-rocketchat
-USER hubot
+COPY --chown=hubot:hubot . /home/hubot/node_modules/hubot-rocketchat
 
 RUN cd /home/hubot/node_modules/hubot-rocketchat && \
 	npm install && \


### PR DESCRIPTION
[COPY should be used over ADD](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy) and use "--chown=hubot:hubot" to get around the permissions hacks of the past.

cc: @Sing-Li @geekgonecrazy 