### PR TITLE
Fix AttachmentMessage.toString returning an Object

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class AttachmentMessage extends TextMessage {
     this.id = id
   }
   toString () {
-    return this.attachment
+    return this.text
   }
 }
 


### PR DESCRIPTION
Fixes #303 
The attachment link is included at the start of `this.text`